### PR TITLE
Adds optional authentication to MQTT client

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Field    | Default value  | Description
 scheme   | tcp            | tcp or tls 
 host     | localhost      | MQTT broker host name or IP
 port     | 1883 for tcp and 8883 fot tls | MQTT TCP port
+username | N/A            | optional parameter
+password | N/A            | optional parameter
 clientId | MQTT client id | random UUID 
  
 #### var-blacklist:

--- a/src/main/java/ocervinka/plcmqttbridge/mqtt/Mqtt.java
+++ b/src/main/java/ocervinka/plcmqttbridge/mqtt/Mqtt.java
@@ -3,6 +3,7 @@ package ocervinka.plcmqttbridge.mqtt;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
 import java.util.Collection;
 
@@ -14,9 +15,16 @@ public class Mqtt {
 
 
     public void connect(MqttConfig config) throws MqttException {
-        client = new MqttClient(config.getUri(), config.clientId);
+        MemoryPersistence persistence = new MemoryPersistence(); // Added because of some warning during run init
+        client = new MqttClient(config.getUri(), config.clientId, persistence);
 
         MqttConnectOptions options = new MqttConnectOptions();
+        if (config.username != null) {
+            options.setUserName(config.username);
+        }
+        if (config.password != null) {
+            options.setPassword(config.password);
+        }
         options.setAutomaticReconnect(true);
         options.setCleanSession(true);
         options.setConnectionTimeout(10);

--- a/src/main/java/ocervinka/plcmqttbridge/mqtt/MqttConfig.java
+++ b/src/main/java/ocervinka/plcmqttbridge/mqtt/MqttConfig.java
@@ -14,6 +14,10 @@ public class MqttConfig {
     public final String scheme;
     public final String host;
     public final int port;
+    /** Not used if null */
+    public final String username;
+    /** Not used if null */
+    public final char[] password;
     public final String clientId;
 
     @JsonCreator
@@ -21,11 +25,15 @@ public class MqttConfig {
             @JsonProperty("scheme") String scheme,
             @JsonProperty("host") String host,
             @JsonProperty("port") Integer port,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") char[] password,
             @JsonProperty("clientId") String clientId)
     {
         this.scheme = scheme == null ? DEFAULT_SCHEME : scheme;
         this.host = host == null ? DEFAULT_HOST : host;
         this.port = port == null ? (this.scheme.equals(DEFAULT_SCHEME) ? DEFAULT_PORT_TCP : DEFAULT_PORT_TLS) : port;
+        this.username = username;
+        this.password = password;
         this.clientId = clientId == null ? UUID.randomUUID().toString() : clientId;
     }
 

--- a/src/test/java/ocervinka/plcmqttbridge/mqtt/MqttConfigTest.java
+++ b/src/test/java/ocervinka/plcmqttbridge/mqtt/MqttConfigTest.java
@@ -1,0 +1,33 @@
+package ocervinka.plcmqttbridge.mqtt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class MqttConfigTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+
+    @Test
+    public void empty() throws IOException {
+        var mqttConfig = MAPPER.readValue("{}", MqttConfig.class);
+        Assert.assertNotNull(mqttConfig.clientId);
+    }
+
+    @Test
+    public void withCredentials() throws IOException {
+        var mqttConfig = MAPPER.readValue(resource("mqtt-config-with-credentials.json"), MqttConfig.class);
+        Assert.assertEquals("tester", mqttConfig.username);
+        assertArrayEquals("123456".toCharArray(), mqttConfig.password);
+    }
+
+    private static InputStream resource(String resourceFileName) {
+        return MqttConfigTest.class.getClassLoader().getResourceAsStream(resourceFileName);
+    }
+}

--- a/src/test/resources/mqtt-config-with-credentials.json
+++ b/src/test/resources/mqtt-config-with-credentials.json
@@ -1,0 +1,4 @@
+{
+  "username": "tester",
+  "password": "123456"
+}


### PR DESCRIPTION
- Adds optional `username` a `password` fields to MQTT configuration
  which, if present, are used to authenticate MQTT client.
- Uses `MemoryPersistence` as the default persistence which uses
  file system is not required.