### PR TITLE
Adds support for optional variable delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ state-topic    | N/A (required) | MQTT topic used by `plccoms-mqtt-bridge` to pu
 state-function | Noop           | A function to convert value from PLC before it is published to topic (Noop, OneToOn, OnToOne)
 cmd-topic      | N/A            | MQTT topic `plccoms-mqtt-bridge` subscribes to and forwards messages to PLC. The topic name can include {index} to refer to (one-based) capturing group or {0} to refer to a full match.
 cmd-function   | Noop           | A function to convert value read from topic before it is sent to PLC. (Noop, OneToOn, OnToOne)
-delta          | N/A (optional) | Instructs `plccoms` to send updates of numerical values only if they change by more than delta. This can reduce network traffic (including MQTT) caused by e.g. some temperature sensors.
+var-delta      | N/A (optional) | Instructs `plccoms` to send updates of numerical values only if they change by more than delta. This can reduce network traffic (including MQTT) caused by e.g. some temperature sensors.
 log-level      | info           | Log4Jv2 log levels (info, debug, trace)
  
 ### Build and run locally

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ state-topic    | N/A (required) | MQTT topic used by `plccoms-mqtt-bridge` to pu
 state-function | Noop           | A function to convert value from PLC before it is published to topic (Noop, OneToOn, OnToOne)
 cmd-topic      | N/A            | MQTT topic `plccoms-mqtt-bridge` subscribes to and forwards messages to PLC. The topic name can include {index} to refer to (one-based) capturing group or {0} to refer to a full match.
 cmd-function   | Noop           | A function to convert value read from topic before it is sent to PLC. (Noop, OneToOn, OnToOne)
+delta          | N/A (optional) | Instructs `plccoms` to send updates of numerical values only if they change by more than delta. This can reduce network traffic (including MQTT) caused by e.g. some temperature sensors.
 log-level      | info           | Log4Jv2 log levels (info, debug, trace)
  
 ### Build and run locally

--- a/src/main/java/ocervinka/plcmqttbridge/PlcMqttBridge.java
+++ b/src/main/java/ocervinka/plcmqttbridge/PlcMqttBridge.java
@@ -13,12 +13,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.paho.client.mqttv3.MqttException;
 
-import java.awt.desktop.SystemSleepEvent;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 
 public class PlcMqttBridge {
@@ -70,7 +70,7 @@ public class PlcMqttBridge {
         plccomsClient.close();
     }
 
-    private Collection<String> onList(Collection<PlccomsVar> listedVars) {
+    private Collection<PlccomsVar> onList(Collection<PlccomsVar> listedVars) {
         int blacklistedCount = 0;
         Map<String, Integer> blacklistedCountByPattern = new HashMap<>();
         List<String> unmappedVars = new ArrayList<>();
@@ -130,7 +130,9 @@ public class PlcMqttBridge {
             LOGGER.error("Failed to subscribe to topic(s)", e);
         }
 
-        return new ArrayList<>(varMappingsByVariable.keySet());
+        return varMappingsByVariable.entrySet().stream()
+                .map(e -> new PlccomsVar(e.getKey(), e.getValue().config.varDelta))
+                .collect(Collectors.toList());
     }
 
     private void onDiff(PlccomsDiff diff) {

--- a/src/main/java/ocervinka/plcmqttbridge/config/VarMappingConfig.java
+++ b/src/main/java/ocervinka/plcmqttbridge/config/VarMappingConfig.java
@@ -21,6 +21,7 @@ public class VarMappingConfig {
     private static final Function<String, String> ON_TO_ONE = new OnToOne();
 
     public final Pattern varPattern;
+    public final Double varDelta;
     public final MessageFormat stateTopic;
     public final Function<String, String> stateFunction;
     public final MessageFormat cmdTopic;
@@ -30,6 +31,7 @@ public class VarMappingConfig {
     @JsonCreator
     public VarMappingConfig(
             @JsonProperty(value = "var", required = true) String var,
+            @JsonProperty("var-delta") Double varDelta,
             @JsonProperty(value = "state-topic", required = true) String stateTopic,
             @JsonProperty("state-function") String stateFunction,
             @JsonProperty("cmd-topic") String cmdTopic,
@@ -37,6 +39,7 @@ public class VarMappingConfig {
             @JsonProperty("log-level") String logLevel)
     {
         this.varPattern = Pattern.compile(var);
+        this.varDelta = varDelta;
         this.stateTopic = new MessageFormat(stateTopic);
         this.stateFunction = getFunction(stateFunction);
         this.cmdTopic = cmdTopic == null ? null : new MessageFormat(cmdTopic);

--- a/src/main/java/ocervinka/plcmqttbridge/plccoms/PlccomsVar.java
+++ b/src/main/java/ocervinka/plcmqttbridge/plccoms/PlccomsVar.java
@@ -3,9 +3,19 @@ package ocervinka.plcmqttbridge.plccoms;
 public class PlccomsVar {
     public final String name;
     public final String type;
+    public final Double delta;
 
-    public PlccomsVar(String name, String type) {
+    public PlccomsVar(String name, String type, Double delta) {
         this.name = name;
         this.type = type;
+        this.delta = delta;
+    }
+
+    public PlccomsVar(String name, String type) {
+        this(name, type, null);
+    }
+
+    public PlccomsVar(String name, Double delta) {
+        this(name, null, delta);
     }
 }


### PR DESCRIPTION
* Adds optional `varDelta` field to `VarMappingConfig`
* Adds optional `delta` field to `PlccomsVar`
* `PlccomsClient` now accepts a list of `PlccomsVar` instead of just
  a list of variable names. This allows the users of `PlccomsClient`
  to subscribe to variable only if it changes by more than user defined
  delta value.
* `PlcMqttBridge` uses this delta parameter from configuration to
  subscribes to variable changes.
* Updates documentation