### PR TITLE
Bumps component versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.util.regex.Pattern
 
 plugins {
     id 'java'
-    id "com.google.cloud.tools.jib" version "2.4.0"
+    id "com.google.cloud.tools.jib" version "3.2.0"
 }
 
 def getVersionTag = { ->
@@ -20,16 +20,16 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.3'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.3'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: "$log4jVersion"
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: "$log4jVersion"
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.0'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.11.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "$jacksonVersion"
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: "$jacksonVersion"
 
-    compile group: 'org.eclipse.paho', name: 'org.eclipse.paho.client.mqttv3', version: '1.2.4'
+    implementation group: 'org.eclipse.paho', name: 'org.eclipse.paho.client.mqttv3', version: "$pahoMqttVersion"
 
 
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 jib {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 mainClass=ocervinka.plcmqttbridge.PlcMqttBridge
+log4jVersion=2.17.1
+jacksonVersion=2.13.1
+pahoMqttVersion=1.2.4


### PR DESCRIPTION
* Bumps log4jv2 vesrsion to address the Log4J Shell vulnerability
  https://www.cve.org/CVERecord?id=CVE-2021-44228
* Bumps version of Jackson and Eclipse Paho client libraries to newest
* Bumps version of JIB Gradle plugin to newest